### PR TITLE
Fix: Allow timzeone to be changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,8 @@ RUN apt-get -y --no-install-recommends install /ubnt-archive-keyring_*_arm64.deb
     && pg_dropcluster --stop 9.6 main \
     && sed -i 's/rm -f/rm -rf/' /sbin/pg-cluster-upgrade \
     && sed -i 's/OLD_DB_CONFDIR=.*/OLD_DB_CONFDIR=\/etc\/postgresql\/9.6\/main/' /sbin/pg-cluster-upgrade
-
+    && chmod 666 /etc/timezone /etc/localtime
+    
 COPY files/sbin /sbin/
 COPY files/usr /usr/
 COPY files/etc /etc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get -y --no-install-recommends install /ubnt-archive-keyring_*_arm64.deb
     && systemctl enable storage_disk dbpermissions\
     && pg_dropcluster --stop 9.6 main \
     && sed -i 's/rm -f/rm -rf/' /sbin/pg-cluster-upgrade \
-    && sed -i 's/OLD_DB_CONFDIR=.*/OLD_DB_CONFDIR=\/etc\/postgresql\/9.6\/main/' /sbin/pg-cluster-upgrade
+    && sed -i 's/OLD_DB_CONFDIR=.*/OLD_DB_CONFDIR=\/etc\/postgresql\/9.6\/main/' /sbin/pg-cluster-upgrade \
     && chmod 666 /etc/timezone /etc/localtime
     
 COPY files/sbin /sbin/


### PR DESCRIPTION
unifi-core is unable to change timezone due to /etc/timezone /etc/localtime being writable only by root. This can result in cameras being updated with the incorrect timezone.

```
error: Failed to change the timezone: Command failed: ubnt-systool timezone Pacific/Auckland
Failed to set time zone: Access denied
rm: cannot remove '/etc/localtime': Permission denied
cp: cannot remove '/etc/localtime': Permission denied
/sbin/ubnt-systool: 234: eval: cannot create /etc/timezone: Permission denied
```